### PR TITLE
Move constants from QUsbModed to base class QUsbMode

### DIFF
--- a/src/qusbmode.cpp
+++ b/src/qusbmode.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "qusbmode.h"
+
+#include "usb_moded-dbus.h"
+#include "usb_moded-modes.h"
+
+// States (from usb_moded-dbus.h)
+const QString QUsbMode::Mode::Connected(USB_CONNECTED);
+const QString QUsbMode::Mode::DataInUse(DATA_IN_USE);
+const QString QUsbMode::Mode::Disconnected(USB_DISCONNECTED);
+const QString QUsbMode::Mode::ModeRequest(USB_CONNECTED_DIALOG_SHOW);
+
+// Modes (from usb_moded-modes.h)
+const QString QUsbMode::Mode::Undefined(MODE_UNDEFINED);
+const QString QUsbMode::Mode::Ask(MODE_ASK);
+const QString QUsbMode::Mode::MassStorage(MODE_MASS_STORAGE);
+const QString QUsbMode::Mode::Developer(MODE_DEVELOPER);
+const QString QUsbMode::Mode::MTP(MODE_MTP);
+const QString QUsbMode::Mode::Host(MODE_HOST);
+const QString QUsbMode::Mode::ConnectionSharing(MODE_CONNECTION_SHARING);
+const QString QUsbMode::Mode::Diag(MODE_DIAG);
+const QString QUsbMode::Mode::Adb(MODE_ADB);
+const QString QUsbMode::Mode::PCSuite(MODE_PC_SUITE);
+const QString QUsbMode::Mode::Charging(MODE_CHARGING);
+const QString QUsbMode::Mode::Charger(MODE_CHARGER);
+
+QUsbMode::QUsbMode(QObject* aParent) :
+    QObject(aParent)
+{
+}

--- a/src/qusbmode.h
+++ b/src/qusbmode.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef QUSBMODE_H
+#define QUSBMODE_H
+
+#include "qusbmoded_types.h"
+
+#include <QObject>
+
+class QUSBMODED_EXPORT QUsbMode : public QObject
+{
+    Q_OBJECT
+
+    // States (from usb_moded-dbus.h)
+    Q_PROPERTY(QString USB_CONNECTED READ USB_CONNECTED CONSTANT)
+    Q_PROPERTY(QString DATA_IN_USE READ DATA_IN_USE CONSTANT)
+    Q_PROPERTY(QString USB_DISCONNECTED READ USB_DISCONNECTED CONSTANT)
+    Q_PROPERTY(QString USB_CONNECTED_DIALOG_SHOW READ USB_CONNECTED_DIALOG_SHOW CONSTANT)
+
+    // Modes (from usb_moded-modes.h)
+    Q_PROPERTY(QString MODE_UNDEFINED READ MODE_UNDEFINED CONSTANT)
+    Q_PROPERTY(QString MODE_ASK READ MODE_ASK CONSTANT)
+    Q_PROPERTY(QString MODE_MASS_STORAGE READ MODE_MASS_STORAGE CONSTANT)
+    Q_PROPERTY(QString MODE_DEVELOPER READ MODE_DEVELOPER CONSTANT)
+    Q_PROPERTY(QString MODE_MTP READ MODE_MTP CONSTANT)
+    Q_PROPERTY(QString MODE_HOST READ MODE_HOST CONSTANT)
+    Q_PROPERTY(QString MODE_CONNECTION_SHARING READ MODE_CONNECTION_SHARING CONSTANT)
+    Q_PROPERTY(QString MODE_DIAG READ MODE_DIAG CONSTANT)
+    Q_PROPERTY(QString MODE_ADB READ MODE_ADB CONSTANT)
+    Q_PROPERTY(QString MODE_PC_SUITE READ MODE_PC_SUITE CONSTANT)
+    Q_PROPERTY(QString MODE_CHARGING READ MODE_CHARGING CONSTANT)
+    Q_PROPERTY(QString MODE_CHARGER READ MODE_CHARGER CONSTANT)
+
+public:
+    class Mode {
+    public:
+        // States (from usb_moded-dbus.h)
+        static const QString Connected;
+        static const QString DataInUse;
+        static const QString Disconnected;
+        static const QString ModeRequest;
+
+        // Modes (from usb_moded-modes.h)
+        static const QString Undefined;
+        static const QString Ask;
+        static const QString MassStorage;
+        static const QString Developer;
+        static const QString MTP;
+        static const QString Host;
+        static const QString ConnectionSharing;
+        static const QString Diag;
+        static const QString Adb;
+        static const QString PCSuite;
+        static const QString Charging;
+        static const QString Charger;
+
+    private:
+        Mode(); // Disallow instantiation
+    };
+
+    QUsbMode(QObject* parent = NULL);
+
+private:
+    // Getters for QML constants
+    QString USB_CONNECTED() const { return Mode::Connected; }
+    QString DATA_IN_USE() const { return Mode::DataInUse; }
+    QString USB_DISCONNECTED() const { return Mode::Disconnected; }
+    QString USB_CONNECTED_DIALOG_SHOW() const { return Mode::ModeRequest; }
+    QString MODE_UNDEFINED() const { return Mode::Undefined; }
+    QString MODE_ASK() const { return Mode::Ask; }
+    QString MODE_MASS_STORAGE() const { return Mode::MassStorage; }
+    QString MODE_DEVELOPER() const { return Mode::Developer; }
+    QString MODE_MTP() const { return Mode::MTP; }
+    QString MODE_HOST() const { return Mode::Host; }
+    QString MODE_CONNECTION_SHARING() const { return Mode::ConnectionSharing; }
+    QString MODE_DIAG() const { return Mode::Diag; }
+    QString MODE_ADB() const { return Mode::Adb; }
+    QString MODE_PC_SUITE() const { return Mode::PCSuite; }
+    QString MODE_CHARGING() const { return Mode::Charging; }
+    QString MODE_CHARGER() const { return Mode::Charger; }
+};
+
+#endif // QUSBMODED_H

--- a/src/qusbmoded.cpp
+++ b/src/qusbmoded.cpp
@@ -36,7 +36,6 @@
 #include "usb_moded_interface.h"
 
 #include "usb_moded-dbus.h"
-#include "usb_moded-modes.h"
 
 #define USB_MODED_CALL_GET_MODES    (0x01)
 #define USB_MODED_CALL_GET_CONFIG   (0x02)
@@ -67,28 +66,8 @@ public:
 const QString QUsbModed::Private::UsbModeSection("usbmode");
 const QString QUsbModed::Private::UsbModeKeyMode("mode");
 
-// States (from usb_moded-dbus.h)
-const QString QUsbModed::Mode::Connected(USB_CONNECTED);
-const QString QUsbModed::Mode::DataInUse(DATA_IN_USE);
-const QString QUsbModed::Mode::Disconnected(USB_DISCONNECTED);
-const QString QUsbModed::Mode::ModeRequest(USB_CONNECTED_DIALOG_SHOW);
-
-// Modes (from usb_moded-modes.h)
-const QString QUsbModed::Mode::Undefined(MODE_UNDEFINED);
-const QString QUsbModed::Mode::Ask(MODE_ASK);
-const QString QUsbModed::Mode::MassStorage(MODE_MASS_STORAGE);
-const QString QUsbModed::Mode::Developer(MODE_DEVELOPER);
-const QString QUsbModed::Mode::MTP(MODE_MTP);
-const QString QUsbModed::Mode::Host(MODE_HOST);
-const QString QUsbModed::Mode::ConnectionSharing(MODE_CONNECTION_SHARING);
-const QString QUsbModed::Mode::Diag(MODE_DIAG);
-const QString QUsbModed::Mode::Adb(MODE_ADB);
-const QString QUsbModed::Mode::PCSuite(MODE_PC_SUITE);
-const QString QUsbModed::Mode::Charging(MODE_CHARGING);
-const QString QUsbModed::Mode::Charger(MODE_CHARGER);
-
 QUsbModed::QUsbModed(QObject* aParent) :
-    QObject(aParent),
+    QUsbMode(aParent),
     iPrivate(new Private)
 {
     QDBusServiceWatcher* serviceWatcher =

--- a/src/qusbmoded.h
+++ b/src/qusbmoded.h
@@ -34,14 +34,13 @@
 #ifndef QUSBMODED_H
 #define QUSBMODED_H
 
-#include "qusbmoded_types.h"
+#include "qusbmode.h"
 
-#include <QObject>
 #include <QStringList>
 
 class QDBusPendingCallWatcher;
 
-class QUSBMODED_EXPORT QUsbModed : public QObject
+class QUSBMODED_EXPORT QUsbModed : public QUsbMode
 {
     Q_OBJECT
     Q_PROPERTY(bool available READ available NOTIFY availableChanged)
@@ -49,53 +48,7 @@ class QUSBMODED_EXPORT QUsbModed : public QObject
     Q_PROPERTY(QString currentMode READ currentMode WRITE setCurrentMode NOTIFY currentModeChanged)
     Q_PROPERTY(QString configMode READ configMode WRITE setConfigMode NOTIFY configModeChanged)
 
-    // States (from usb_moded-dbus.h)
-    Q_PROPERTY(QString USB_CONNECTED READ USB_CONNECTED CONSTANT)
-    Q_PROPERTY(QString DATA_IN_USE READ DATA_IN_USE CONSTANT)
-    Q_PROPERTY(QString USB_DISCONNECTED READ USB_DISCONNECTED CONSTANT)
-    Q_PROPERTY(QString USB_CONNECTED_DIALOG_SHOW READ USB_CONNECTED_DIALOG_SHOW CONSTANT)
-
-    // Modes (from usb_moded-modes.h)
-    Q_PROPERTY(QString MODE_UNDEFINED READ MODE_UNDEFINED CONSTANT)
-    Q_PROPERTY(QString MODE_ASK READ MODE_ASK CONSTANT)
-    Q_PROPERTY(QString MODE_MASS_STORAGE READ MODE_MASS_STORAGE CONSTANT)
-    Q_PROPERTY(QString MODE_DEVELOPER READ MODE_DEVELOPER CONSTANT)
-    Q_PROPERTY(QString MODE_MTP READ MODE_MTP CONSTANT)
-    Q_PROPERTY(QString MODE_HOST READ MODE_HOST CONSTANT)
-    Q_PROPERTY(QString MODE_CONNECTION_SHARING READ MODE_CONNECTION_SHARING CONSTANT)
-    Q_PROPERTY(QString MODE_DIAG READ MODE_DIAG CONSTANT)
-    Q_PROPERTY(QString MODE_ADB READ MODE_ADB CONSTANT)
-    Q_PROPERTY(QString MODE_PC_SUITE READ MODE_PC_SUITE CONSTANT)
-    Q_PROPERTY(QString MODE_CHARGING READ MODE_CHARGING CONSTANT)
-    Q_PROPERTY(QString MODE_CHARGER READ MODE_CHARGER CONSTANT)
-
 public:
-    class Mode {
-    public:
-        // States (from usb_moded-dbus.h)
-        static const QString Connected;
-        static const QString DataInUse;
-        static const QString Disconnected;
-        static const QString ModeRequest;
-
-        // Modes (from usb_moded-modes.h)
-        static const QString Undefined;
-        static const QString Ask;
-        static const QString MassStorage;
-        static const QString Developer;
-        static const QString MTP;
-        static const QString Host;
-        static const QString ConnectionSharing;
-        static const QString Diag;
-        static const QString Adb;
-        static const QString PCSuite;
-        static const QString Charging;
-        static const QString Charger;
-
-    private:
-        Mode(); // Disallow instantiation
-    };
-
     explicit QUsbModed(QObject* parent = NULL);
     ~QUsbModed();
 
@@ -106,25 +59,6 @@ public:
 
     bool setCurrentMode(QString mode);
     bool setConfigMode(QString mode);
-
-private:
-    // Getters for QML constants
-    QString USB_CONNECTED() const { return Mode::Connected; }
-    QString DATA_IN_USE() const { return Mode::DataInUse; }
-    QString USB_DISCONNECTED() const { return Mode::Disconnected; }
-    QString USB_CONNECTED_DIALOG_SHOW() const { return Mode::ModeRequest; }
-    QString MODE_UNDEFINED() const { return Mode::Undefined; }
-    QString MODE_ASK() const { return Mode::Ask; }
-    QString MODE_MASS_STORAGE() const { return Mode::MassStorage; }
-    QString MODE_DEVELOPER() const { return Mode::Developer; }
-    QString MODE_MTP() const { return Mode::MTP; }
-    QString MODE_HOST() const { return Mode::Host; }
-    QString MODE_CONNECTION_SHARING() const { return Mode::ConnectionSharing; }
-    QString MODE_DIAG() const { return Mode::Diag; }
-    QString MODE_ADB() const { return Mode::Adb; }
-    QString MODE_PC_SUITE() const { return Mode::PCSuite; }
-    QString MODE_CHARGING() const { return Mode::Charging; }
-    QString MODE_CHARGER() const { return Mode::Charger; }
 
 Q_SIGNALS:
     void availableChanged();

--- a/src/src.pro
+++ b/src/src.pro
@@ -14,9 +14,11 @@ CONFIG(debug, debug|release) {
 }
 
 SOURCES += \
+    qusbmode.cpp \
     qusbmoded.cpp
 
 PUBLIC_HEADERS += \
+    qusbmode.h \
     qusbmoded.h \
     qusbmoded_types.h
 


### PR DESCRIPTION
`QUsbMode` can be used for the purposes of exporting USB mode constants to QML. Unlike `QUsbModed`, its instantiation doesn't involve any D-Bus action. Primarily for unit-testing.
